### PR TITLE
Added dark-mode cookie and minor fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ function isInArray(value, array) {
 consola.success(chalk.greenBright('Fetching messages...'));
 let fetched = false;
 
-if (twitchChannelsArgs === '') {
+if (twitchChannelsArgs.length === 0) {
   consola.info('No Channels added, go to http://localhost:8080 to add or remove channels'); 
 }
 

--- a/web/app.js
+++ b/web/app.js
@@ -6,7 +6,9 @@ const renderChats = (channels) => {
     if (!$(c).length) {
       $('#chatRooms').append(`
         <div class="chats" id="${c.replace('#', '')}">
-          <h3>${c}</h3>
+          <a href="https://www.twitch.tv/${c.replace('#', '')}" target="_blank">
+            <h3>${c}</h3>
+          </a>
         </div>
       `);
       $('#channelList').append(`
@@ -63,12 +65,35 @@ socket.on('chat', (message) => {
   renderMessage(message);
 });
 
+const isDarkModeStr = document.cookie
+  .split('; ')
+  .find((row) => row.startsWith('dark-mode'))
+  .split('=')[1];
+
+const isDarkMode = isDarkModeStr == 'true';
+
+if (isDarkMode) {
+  $('input.checkbox').prop('checked', true);
+  $('.theme').attr('href', 'themes/dark.css');
+  $('#channel-table').attr('class', 'table table-dark');
+} else {
+  $('.theme').attr('href', 'themes/styles.css');
+  $('#channel-table').attr('class', 'table');
+}
+
 $('.checkbox').click(() => {
+  date = new Date();
+  date.setTime(date.getTime() + 30 * 24 * 60 * 60 * 1000);
+  expires = date.toUTCString();
   if ($('input.checkbox').is(':checked')) {
     $('.theme').attr('href', 'themes/dark.css');
-    $('#channel-table').attr('class','table table-dark');
+    $('#channel-table').attr('class', 'table table-dark');
+    darkMode = true;
   } else {
     $('.theme').attr('href', 'themes/styles.css');
-    $('#channel-table').attr('class','table');
+    $('#channel-table').attr('class', 'table');
+    darkMode = false;
   }
+  // create a cookie that expires after 30 days
+  document.cookie = `dark-mode=${darkMode};Expires=${expires};Max-age=2592000;SameSite=Strict`;
 });

--- a/web/app.js
+++ b/web/app.js
@@ -65,10 +65,14 @@ socket.on('chat', (message) => {
   renderMessage(message);
 });
 
-const isDarkModeStr = document.cookie
-  .split('; ')
-  .find((row) => row.startsWith('dark-mode'))
-  .split('=')[1];
+let isDarkModeStr = false;
+
+if (document.cookie) {
+  isDarkModeStr = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('dark-mode'))
+    .split('=')[1];
+}
 
 const isDarkMode = isDarkModeStr == 'true';
 

--- a/web/index.html
+++ b/web/index.html
@@ -23,7 +23,7 @@
         <div class="row mb-3 m-3 pl-3">
           <p class="label-dark-mode">Dark mode</p>
           <label class="switch">
-            <input type="checkbox" class="checkbox" />
+            <input type="checkbox" class="checkbox" autocomplete="off"/>
             <span class="slider round"></span>
           </label>
         </div>

--- a/web/themes/dark.css
+++ b/web/themes/dark.css
@@ -24,6 +24,10 @@ body {
   color: white;
 }
 
+.chats a {
+  color: white;
+}
+
 .nav-col {
   height: 100vh;
   width: 264px;

--- a/web/themes/styles.css
+++ b/web/themes/styles.css
@@ -30,6 +30,10 @@ h3 {
   margin-top: 0;
 }
 
+.chats a {
+  color: black;
+}
+
 .chats {
   float: left;
   height: 460px;


### PR DESCRIPTION
Hi all,
I fixed an issue where the consla info wasn't being shown with no `twitchChannelsArgs` and fixed the slider from autocomplete (e.g. stuck on dark-mode when refreshing the webpage). Additionally, I added the ability to navigate to the channel on Twitch by clicking the name on the local website. Lastly, I added a cookie for the dark-mode slider, so that your preference will be saved. The cookie lasts for 30 days, and refreshes every time the slider is changed.

Please take a look, thank you.


